### PR TITLE
Added libssl-dev to Memtier required pacakges

### DIFF
--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -13,7 +13,7 @@ KeyDB is multithreaded on several levels and seeing the differences becomes appa
 
 You can visit [memtiers github rep](https://github.com/RedisLabs/memtier_benchmark) or follow these quick steps to get up and running on typical Ubuntu/Debian:
 ```
-apt-get install build-essential autoconf automake libpcre3-dev libevent-dev pkg-config zlib1g-dev
+apt-get install build-essential autoconf automake libpcre3-dev libevent-dev pkg-config zlib1g-dev libssl-dev
 git clone https://github.com/RedisLabs/memtier_benchmark.git
 cd memtier_benchmark
 autoreconf -ivf


### PR DESCRIPTION
`libssl-dev` is one of prerequisites as you can see in:

https://github.com/RedisLabs/memtier_benchmark?tab=readme-ov-file#ubuntudebian